### PR TITLE
Release PR に常に「### Related Stories <!-- ${basehead} -->」を書く

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,9 +130,7 @@ async function main(args) {
 
     const related_stories = [];
 
-    if (pulls.length > 0 || issues.length > 0) {
-      related_stories.push(`### Related Stories <!-- ${basehead} -->`, "\n");
-    }
+    related_stories.push(`### Related Stories <!-- ${basehead} -->`, "\n");
 
     if (pulls.length > 0) {
       related_stories.push("*PullRequests*", "\n");


### PR DESCRIPTION
## 問題
PR 無しの commit の push で Release が新規に作られた後に，追加で push があるとバグる (ref: https://github.com/themintjp/mint-console/pull/151)

## 原因
PR 無しの commit の push では説明のない Release PR ができて，また，以下の部分
https://github.com/themintjp/gha-create-pull-request/blob/4ef36f9c10119ca65b215cd9b899b41a8b75d52a/index.js#L68
で Release PR に説明がないと `release_pull.body` は `null` になるらしいため

## 対策
`body` が `null` かチェックするなどの処理が必要かもしれないけど，そもそも base と head の情報は Release PR には常に入れたくて `### Related Stories <!-- ${basehead} -->` の行は story (pull, issue) の有無に関わらず入れても問題ないはずなのでそうする。暫定対応ぽいけどこれで `body` が `null` になることはなくなると思うので

## 動作確認
どうやればいいのかよくわからないのでお任せしたい